### PR TITLE
Use the right timezone for determining when today starts and ends

### DIFF
--- a/spothinta_api/const.py
+++ b/spothinta_api/const.py
@@ -1,6 +1,7 @@
 """Constants for SpotHinta API client."""
 from enum import Enum, unique
 from typing import Final
+from zoneinfo import ZoneInfo
 
 API_HOST: Final = "api.spot-hinta.fi"
 
@@ -24,3 +25,22 @@ class Region(Enum):
     SE2 = 12
     SE3 = 13
     SE4 = 14
+
+
+REGION_TO_TIMEZONE: dict[Region, ZoneInfo] = {
+    Region.DK1: ZoneInfo("Europe/Copenhagen"),
+    Region.DK2: ZoneInfo("Europe/Copenhagen"),
+    Region.FI: ZoneInfo("Europe/Helsinki"),
+    Region.EE: ZoneInfo("Europe/Tallinn"),
+    Region.LT: ZoneInfo("Europe/Vilnius"),
+    Region.LV: ZoneInfo("Europe/Riga"),
+    Region.NO1: ZoneInfo("Europe/Oslo"),
+    Region.NO2: ZoneInfo("Europe/Oslo"),
+    Region.NO3: ZoneInfo("Europe/Oslo"),
+    Region.NO4: ZoneInfo("Europe/Oslo"),
+    Region.NO5: ZoneInfo("Europe/Oslo"),
+    Region.SE1: ZoneInfo("Europe/Stockholm"),
+    Region.SE2: ZoneInfo("Europe/Stockholm"),
+    Region.SE3: ZoneInfo("Europe/Stockholm"),
+    Region.SE4: ZoneInfo("Europe/Stockholm"),
+}

--- a/spothinta_api/models.py
+++ b/spothinta_api/models.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from zoneinfo import ZoneInfo
 
 
 def _timed_value(moment: datetime, prices: dict[datetime, float]) -> float | None:
@@ -55,6 +56,7 @@ class Electricity:
     """Object representing electricity data."""
 
     prices: dict[datetime, float]
+    time_zone: ZoneInfo
 
     @property
     def current_price(self) -> float | None:
@@ -170,7 +172,7 @@ class Electricity:
             The prices for today.
         """
         prices_today = {}
-        today = datetime.utcnow().astimezone().date()  # noqa: DTZ003
+        today = datetime.now(tz=self.time_zone).astimezone().date()
         for timestamp, price in self.prices.items():
             if timestamp.date() == today:
                 prices_today[timestamp] = price
@@ -224,12 +226,17 @@ class Electricity:
         return None
 
     @classmethod
-    def from_dict(cls: type[Electricity], data: list[dict[str, Any]]) -> Electricity:
+    def from_dict(
+        cls: type[Electricity],
+        data: list[dict[str, Any]],
+        time_zone: ZoneInfo,
+    ) -> Electricity:
         """Create an Electricity object from a dictionary.
 
         Args:
         ----
             data: A dictionary with the data from the API.
+            time_zone: The timezone to use for determining "today" and "tomorrow".
 
         Returns:
         -------
@@ -242,4 +249,5 @@ class Electricity:
             ]
         return cls(
             prices=prices,
+            time_zone=time_zone,
         )

--- a/spothinta_api/spothinta.py
+++ b/spothinta_api/spothinta.py
@@ -13,7 +13,7 @@ from aiohttp.client import ClientError, ClientSession
 from aiohttp.hdrs import METH_GET
 from yarl import URL
 
-from .const import API_HOST, Region
+from .const import API_HOST, REGION_TO_TIMEZONE, Region
 from .exceptions import (
     SpotHintaConnectionError,
     SpotHintaError,
@@ -137,7 +137,9 @@ class SpotHinta:
         if len(data) == 0:
             msg = "No energy prices found."
             raise SpotHintaNoDataError(msg)
-        return Electricity.from_dict(data)
+
+        time_zone = REGION_TO_TIMEZONE[region]
+        return Electricity.from_dict(data, time_zone=time_zone)
 
     async def close(self) -> None:
         """Close open client session."""

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,0 +1,10 @@
+"""Tests for regions."""
+from zoneinfo import ZoneInfo
+
+from spothinta_api.const import REGION_TO_TIMEZONE, Region
+
+
+async def test_each_region_has_a_time_zone() -> None:
+    """Tests that each region has a time zone set."""
+    for region in Region:
+        assert isinstance(REGION_TO_TIMEZONE[region], ZoneInfo)


### PR DESCRIPTION
Previously, UTC was used for determining when "today" ends and "tomorrow" starts. This meant that average, maximum and minimum prices were updated at the wrong time.

The way this is fixed right now is to use hardcoded timezones depending on the region used.